### PR TITLE
Fix: changed profile avatar from button to div

### DIFF
--- a/src/components/profileCircleAvatar/ProfileCircleAvatar.js
+++ b/src/components/profileCircleAvatar/ProfileCircleAvatar.js
@@ -4,24 +4,13 @@ import PropTypes from "prop-types";
 import { getInitials } from "./ProfileCircleAvatar.utils";
 import DefaultStyles from "./ProfileCircleAvatar.module.css";
 
-function ProfileCircleAvatar({ styles, name, onClick }) {
+function ProfileCircleAvatar({ styles, name }) {
   const initials = getInitials(name);
 
-  if (onClick) {
-    styles = {
-      ...styles,
-      cursor: "pointer",
-    };
-  }
-
   return (
-    <button
-      className={DefaultStyles.container}
-      style={styles}
-      onClick={onClick}
-    >
+    <div className={DefaultStyles.container} style={styles}>
       {initials}
-    </button>
+    </div>
   );
 }
 
@@ -31,11 +20,6 @@ ProfileCircleAvatar.propTypes = {
 
 ProfileCircleAvatar.defaultProps = {
   styles: {},
-  onClick: null,
 };
 
 export default ProfileCircleAvatar;
-
-ProfileCircleAvatar.prototype = {
-  name: PropTypes.string,
-};

--- a/src/screens/dashboard/components/header/Header.js
+++ b/src/screens/dashboard/components/header/Header.js
@@ -32,11 +32,15 @@ function Header() {
 
   const UserProfileBox = useMemo(() => {
     return (
-      <ProfileCircleAvatar
-        name={usersState.currentUser.name}
-        styles={HEADER_CIRCLE_AVATAR_STYLES}
+      <button
+        className={styles.userProfileBox}
         onClick={handleOpenProfileDropdown}
-      />
+      >
+        <ProfileCircleAvatar
+          name={usersState.currentUser.name}
+          styles={HEADER_CIRCLE_AVATAR_STYLES}
+        />
+      </button>
     );
   }, [usersState.currentUser.name]);
 

--- a/src/screens/dashboard/components/header/Header.module.css
+++ b/src/screens/dashboard/components/header/Header.module.css
@@ -7,6 +7,14 @@
   justify-content: space-around;
 }
 
+.userProfileBox {
+  border: none;
+  background-color: transparent;
+  padding: none;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
 .profileDropdown {
   display: flex;
   background-color: white;


### PR DESCRIPTION
- It was required because at multiple places we were getting error that a button cannot be a child of another button.
- Now the Profile Avatar is a div, and to add any onClick functionality, it should be written inside a button.